### PR TITLE
Give option to not override files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,22 @@ Type: `String`
 The path to the Karma configuration file.
 
 #### options.action
-Type: `String`  
+Type: `String`
 Default: `run`
 
 One of the following:
 
   * **`run`**: Start the server, run tests once, then exit.
   * **`watch`**: Start the server, run tests once, then watch for changes and run when files change.
+
+#### options.noOverrideFiles
+Type: `Boolean`
+Default: `false`
+
+One of the following:
+
+  * **`true`**: Use paths supplied from `gulp.src()` as the `files` option for Karma.
+  * **`false`**: Don't do that (helpful when using the `{included: false}` option, such as running with RequireJS).
 
 #### options.*
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var server = require('karma').server;
 var karmaPlugin = function(options) {
   var child;
   var stream;
+  var overrideFiles = !options.noOverrideFiles;
   var files = [];
 
   options = extend({
@@ -24,6 +25,7 @@ var karmaPlugin = function(options) {
 
   // Remove option in case Karma uses it in the future
   delete options.action;
+  delete options.noOverrideFiles;
 
   if (action === 'watch') {
     // Never set singleRun in background mode
@@ -91,7 +93,7 @@ var karmaPlugin = function(options) {
   function endStream() {
     // Override files if they were piped
     // This doesn't work with the runner, but works fine with singleRun and autoWatch
-    if (files.length) {
+    if (files.length && overrideFiles) {
       options.files = files;
     }
 


### PR DESCRIPTION
This is useful for situations in which overriding Karma's file list will break a test suite (such as when using RequireJS and the no-include file option). It's a minimal change that has no impact on behavior when the feature isn't opted in to.
