### PR TITLE
Update `gulp-util`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "optimist": "~0.6.0",
-    "gulp-util": "~1.2.0",
+    "gulp-util": "~2.2.14",
     "xtend": "~2.1.1",
     "event-stream": "~3.0.20"
   },


### PR DESCRIPTION
This update was originally integrated in https://github.com/lazd/gulp-karma/pull/19, but didn't wind up in `master`. The issue is current master has:

``` js
stream.emit('error', new gutil.PluginError('gulp-karma', 'karma exited with code ' + code));
```

But the version of `gulp-utils` doesn't have `PluginError`, yielding:

```
/PATH/TO/REPO/node_modules/gulp-karma/index.js:57
        stream.emit('error', new gutil.PluginError('gulp-karma', 'karma exited
                             ^
TypeError: undefined is not a function
    at done (/PATH/TO/REPO/node_modules/gulp-karma/index.js:57:30)
    at ChildProcess.<anonymous> (/PATH/TO/REPO/node_modules/gulp-karma/index.js:83:7)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at Process.ChildProcess._handle.onexit (child_process.js:797:12)
```

on a test error...
