### PR TITLE
Make sure that Karma can launch even if node.js is not in the system pat...

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ var karmaPlugin = function(options) {
 
     // Start the server
     child = spawn(
-      'node',
+      process.execPath,
       [
         path.join(__dirname, 'lib', 'background.js'),
         JSON.stringify(options)


### PR DESCRIPTION
...h. Use the same executable node that launched gulp-karma.