### PR TITLE
Change command-line arg to stdin to fix Win32 bug for command lines > 8k

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,15 +66,16 @@ var karmaPlugin = function(options) {
 
     // Start the server
     child = spawn(
-      'node',
-      [
-        path.join(__dirname, 'lib', 'background.js'),
-        JSON.stringify(options)
-      ],
-      {
-        stdio: 'inherit'
-      }
+        'node',
+        [
+          path.join(__dirname, 'lib', 'background.js')
+        ],
+        {
+          stdio: ['pipe', process.stdout, process.stderr]
+        }
     );
+    child.stdin.write(JSON.stringify(options));
+    child.stdin.end();
 
     // Cleanup when the child process exits
     child.on('exit', function(code) {

--- a/lib/background.js
+++ b/lib/background.js
@@ -1,3 +1,8 @@
 var server = require('karma').server;
-var data = JSON.parse(process.argv[2]);
-server.start(data);
+process.stdin.on('readable', function () {
+    var list = process.stdin.read();
+    if (list) {
+        var data = JSON.parse(list);
+        server.start(data);
+    }
+});


### PR DESCRIPTION
This fixes a problem on Windows where gulp-karma crashes once the list of files grows to the point where the command line exceeds 8k (8192 bytes). Instead it passes the jsonified options to the child process using stdin.