### PR TITLE
updated for Karma 0.14

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -1,3 +1,4 @@
-var server = require('karma').server;
+var Server = require('karma').Server;
 var data = JSON.parse(process.argv[2]);
-server.start(data);
+var server = new Server(data);
+server.start();


### PR DESCRIPTION
This warning started coming up:
```
WARN `start` method is deprecated since 0.13. It will be removed in 0.14. Please use 
  server = new Server(config, [done])
  server.start()
instead.
```