### PR TITLE
Update background.js

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -1,3 +1,4 @@
-var server = require('karma').server;
+var Server = require('karma').Server;
 var data = JSON.parse(process.argv[2]);
+var server = new Server(data);
 server.start(data);


### PR DESCRIPTION
Since Karma 0.13, the following warning displayed below is logged when using gulp-karma. I changed the implementation to remove the warning and prevent problems for the upcoming Karma 0.14 release.

The warning:

WARN `start` method is deprecated since 0.13. It will be removed in 0.14. Please use

  server = new Server(config, [done])
  server.start()

instead.